### PR TITLE
Feat/#15 TimeTable CRUD, Search, Restore 기능 구현

### DIFF
--- a/com.culture-ticket.client.gateway/src/main/resources/application.yml
+++ b/com.culture-ticket.client.gateway/src/main/resources/application.yml
@@ -17,16 +17,12 @@ spring:
         - id: performance-service
           uri: lb://performance-service
           predicates:
-            - Path=/api/v1/categories/**
-            - Path=/api/v1/performances/**
-            - Path=/api/v1/timetables/**
-            - Path=/api/v1/seats/**
+            - Path=/api/v1/performances/**, /api/v1/categories/**, /api/v1/timetables/**, /api/v1/seats/**
 
         - id: reservation-payment-service
           uri: lb://reservation-payment-service
           predicates:
-            - Path=/api/v1/reservations/**
-            - Path=/api/v1/payments/**
+            - Path=/api/v1/reservations/**, /api/v1/payments/**
 
         - id: ticket-service
           uri: lb://ticket-service

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/TimeTableCreateRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/TimeTableCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.culture_ticket.client.performance.application.dto.requestDto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class TimeTableCreateRequestDto {
+  private UUID performanceId;
+  private LocalDate date;
+  private LocalTime startTime;
+  private LocalTime endTime;
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/TimeTableCreateRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/TimeTableCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.culture_ticket.client.performance.application.dto.requestDto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
@@ -9,6 +10,8 @@ import lombok.Getter;
 public class TimeTableCreateRequestDto {
   private UUID performanceId;
   private LocalDate date;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
   private LocalTime startTime;
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
   private LocalTime endTime;
 }

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/TimeTableSearchRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/TimeTableSearchRequestDto.java
@@ -1,0 +1,20 @@
+package com.culture_ticket.client.performance.application.dto.requestDto;
+
+import com.culture_ticket.client.performance.domain.model.TimeTableStatus;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TimeTableSearchRequestDto {
+
+  private UUID performanceId;
+  private LocalDate date;
+  private LocalTime startTime;
+  private LocalTime endTime;
+  private TimeTableStatus timeTableStatus;
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/responseDto/TimeTableSearchResponseDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/responseDto/TimeTableSearchResponseDto.java
@@ -1,0 +1,19 @@
+package com.culture_ticket.client.performance.application.dto.responseDto;
+
+import com.culture_ticket.client.performance.domain.model.TimeTableStatus;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeTableSearchResponseDto {
+
+  private LocalDate date;
+  private LocalTime startTime;
+  private LocalTime endTime;
+  private TimeTableStatus timeTableStatus;
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/SeatService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/SeatService.java
@@ -1,0 +1,5 @@
+package com.culture_ticket.client.performance.application.service;
+
+public class SeatService {
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
@@ -32,7 +32,7 @@ public class TimeTableService {
     timeTableRepository.save(TimeTable.of(requestDto, username));
   }
 
-  public List<TimeTableSearchResponseDto> searchTimeTables(TimeTableSearchRequestDto requestDto, String role) {
+  public List<TimeTableSearchResponseDto> searchTimeTables(TimeTableSearchRequestDto requestDto) {
     return timeTableRepository.searchTimeTable(requestDto);
   }
 

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
@@ -3,10 +3,14 @@ package com.culture_ticket.client.performance.application.service;
 import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableCreateRequestDto;
 import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableSearchRequestDto;
 import com.culture_ticket.client.performance.application.dto.responseDto.TimeTableSearchResponseDto;
+import com.culture_ticket.client.performance.common.CustomException;
+import com.culture_ticket.client.performance.common.ErrorType;
 import com.culture_ticket.client.performance.common.util.RoleValidator;
 import com.culture_ticket.client.performance.domain.model.TimeTable;
+import com.culture_ticket.client.performance.domain.model.TimeTableStatus;
 import com.culture_ticket.client.performance.domain.repository.TimeTableRepository;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,12 +22,36 @@ public class TimeTableService {
 
   private final TimeTableRepository timeTableRepository;
 
-  public void createTimeTable(TimeTableCreateRequestDto requestDto, String role) {
+  public void createTimeTable(TimeTableCreateRequestDto requestDto, String username, String role) {
     RoleValidator.validateIsAdmin(role);
-    timeTableRepository.save(TimeTable.from(requestDto));
+    timeTableRepository.save(TimeTable.of(requestDto, username));
   }
 
   public List<TimeTableSearchResponseDto> searchTimeTables(TimeTableSearchRequestDto requestDto, String role) {
     return timeTableRepository.searchTimeTable(requestDto);
+  }
+
+  public void updateTimeTableStatus(UUID timeTableId, TimeTableStatus timeTableStatus, String username, String role) {
+    RoleValidator.validateIsAdmin(role);
+    TimeTable timeTable = timeTableRepository.findById(timeTableId).orElseThrow(
+        () -> new CustomException(ErrorType.TIMETABLE_NOT_FOUND)
+    );
+    timeTable.updateStatus(timeTableStatus, username);
+  }
+
+  public void deleteTimeTable(UUID timeTableId, String username, String role) {
+    RoleValidator.validateIsAdmin(role);
+    TimeTable timeTable = timeTableRepository.findById(timeTableId).orElseThrow(
+        () -> new CustomException(ErrorType.TIMETABLE_NOT_FOUND)
+    );
+    timeTable.deleted(username);
+  }
+
+  public void restoreTimeTable(UUID timeTableId, String username, String role) {
+    RoleValidator.validateIsAdmin(role);
+    TimeTable timeTable = timeTableRepository.findById(timeTableId).orElseThrow(
+        () -> new CustomException(ErrorType.TIMETABLE_NOT_FOUND)
+    );
+    timeTable.restore(username);
   }
 }

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
@@ -8,6 +8,7 @@ import com.culture_ticket.client.performance.common.ErrorType;
 import com.culture_ticket.client.performance.common.util.RoleValidator;
 import com.culture_ticket.client.performance.domain.model.TimeTable;
 import com.culture_ticket.client.performance.domain.model.TimeTableStatus;
+import com.culture_ticket.client.performance.domain.repository.PerformanceRepository;
 import com.culture_ticket.client.performance.domain.repository.TimeTableRepository;
 import java.util.List;
 import java.util.UUID;
@@ -21,9 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class TimeTableService {
 
   private final TimeTableRepository timeTableRepository;
+  private final PerformanceRepository performanceRepository;
 
   public void createTimeTable(TimeTableCreateRequestDto requestDto, String username, String role) {
     RoleValidator.validateIsAdmin(role);
+    performanceRepository.findById(requestDto.getPerformanceId()).orElseThrow(
+        () -> new CustomException(ErrorType.PERFORMANCE_NOT_FOUND)
+    );
     timeTableRepository.save(TimeTable.of(requestDto, username));
   }
 

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
@@ -1,0 +1,29 @@
+package com.culture_ticket.client.performance.application.service;
+
+import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableCreateRequestDto;
+import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableSearchRequestDto;
+import com.culture_ticket.client.performance.application.dto.responseDto.TimeTableSearchResponseDto;
+import com.culture_ticket.client.performance.common.util.RoleValidator;
+import com.culture_ticket.client.performance.domain.model.TimeTable;
+import com.culture_ticket.client.performance.domain.repository.TimeTableRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TimeTableService {
+
+  private final TimeTableRepository timeTableRepository;
+
+  public void createTimeTable(TimeTableCreateRequestDto requestDto, String role) {
+    RoleValidator.validateIsAdmin(role);
+    timeTableRepository.save(TimeTable.from(requestDto));
+  }
+
+  public List<TimeTableSearchResponseDto> searchTimeTables(TimeTableSearchRequestDto requestDto, String role) {
+    return timeTableRepository.searchTimeTable(requestDto);
+  }
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ErrorType.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ErrorType.java
@@ -7,26 +7,21 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorType {
-    //   사용예시
-    //user
-//    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이메일이 이미 사용 중입니다."),
-//    INVALID_EMAIL_OR_PASSWORD(HttpStatus.LOCKED, "이메일 또는 비밀번호가 잘못되었습니다."),
-//    NOT_FOUND_USER(HttpStatus.LOCKED, "존재하지 않는 회원입니다."),
-//    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "이메일이 존재하지 않습니다."),
-//    NOT_AVAILABLE_PERMISSION(HttpStatus.LOCKED, "권한이 없습니다."),
-//    ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
-//    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "로그인 실패"),
-//    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh Token이 존재하지 않습니다. 다시 로그인 해주세요."),
-//    NOT_ACCESS_TOKEN(HttpStatus.NOT_FOUND, "Access Token이 존재하지 않습니다."),
-//    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "본인 정보만 접근할 수 있습니다."),
 
+    // Category
     CATEGORY_DUPLICATE(HttpStatus.CONFLICT, "카테고리가 이미 존재합니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
+    // Performance
     PERFORMANCE_DUPLICATE(HttpStatus.CONFLICT, "공연이 이미 존재합니다."),
     PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "공연을 찾을 수 없습니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+
+    // TimeTable
+
+    // Role
+    ROLE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다.");
+
 
 
     private final HttpStatus httpStatus;

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ErrorType.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ErrorType.java
@@ -20,7 +20,8 @@ public enum ErrorType {
     // TimeTable
 
     // Role
-    ROLE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다.");
+    ROLE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
+    TIMETABLE_NOT_FOUND(HttpStatus.NOT_FOUND, "타임테이블을 찾을 수 없습니다.");
 
 
 

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
@@ -37,8 +37,11 @@ public enum ResponseStatus {
     DELETE_PERFORMANCE_SUCCESS(HttpStatus.OK, "공연 삭제에 성공했습니다."),
 
     // timetable
-    CREATE_TIME_TABLE_SUCCESS(HttpStatus.OK, "타임 테이블 생성에 성공하였습니다."),
-    SEARCH_TIME_TABLE_SUCCESS(HttpStatus.OK, "타임 테이블 검색에 성공했습니다.");
+    CREATE_TIME_TABLE_SUCCESS(HttpStatus.OK, "타임테이블 생성에 성공하였습니다."),
+    SEARCH_TIME_TABLE_SUCCESS(HttpStatus.OK, "타임테이블 검색에 성공했습니다."),
+    UPDATE_TIMETABLE_STATUS_SUCCESS(HttpStatus.OK, "타임테이블 상태 변경에 성공했습니다."),
+    DELETE_TIMETABLE_SUCCESS(HttpStatus.OK, "타임테이블 삭제에 성공했습니다."),
+    RESTORE_TIMETABLE_SUCCESS(HttpStatus.OK, "타임테이블 복원에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
@@ -34,7 +34,11 @@ public enum ResponseStatus {
     GET_PERFORMANCE_SUCCESS(HttpStatus.OK, "공연 조회에 성공했습니다."),
     UPDATE_PERFORMANCE_STATUS_SUCCESS(HttpStatus.OK, "공연 상태 수정에 성공했습니다."),
     UPDATE_PERFORMANCE(HttpStatus.OK, "공연 수정에 성공했습니다."),
-    DELETE_PERFORMANCE_SUCCESS(HttpStatus.OK, "공연 삭제에 성공했습니다.");
+    DELETE_PERFORMANCE_SUCCESS(HttpStatus.OK, "공연 삭제에 성공했습니다."),
+
+    // timetable
+    CREATE_TIME_TABLE_SUCCESS(HttpStatus.OK, "타임 테이블 생성에 성공하였습니다."),
+    SEARCH_TIME_TABLE_SUCCESS(HttpStatus.OK, "타임 테이블 검색에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/RoleValidator.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/RoleValidator.java
@@ -1,0 +1,23 @@
+package com.culture_ticket.client.performance.common.util;
+
+import com.culture_ticket.client.performance.common.CustomException;
+import com.culture_ticket.client.performance.common.ErrorType;
+
+public class RoleValidator {
+
+  private final static String ADMIN = "ADMIN";
+  private final static String USER = "USER";
+
+  public static void validateIsAdmin(String role){
+    if (!role.equals(ADMIN)){
+      throw new CustomException(ErrorType.ROLE_UNAUTHORIZED);
+    }
+  }
+
+  public static void validateIsUSER(String role){
+    if (!role.equals(USER)){
+      throw new CustomException(ErrorType.ROLE_UNAUTHORIZED);
+    }
+  }
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/BaseEntity.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/BaseEntity.java
@@ -46,11 +46,13 @@ public abstract class BaseEntity {
         this.isDeleted = true;
         this.deletedBy = username;
         this.deletedAt = LocalDateTime.now();
+        this.updatedBy = username;
     }
 
     protected void restoreBy(String username){
         this.isDeleted = false;
         this.deletedBy = null;
         this.deletedAt = null;
+        this.updatedBy = username;
     }
 }

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/Performance.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/Performance.java
@@ -42,6 +42,7 @@ public class Performance extends BaseEntity {
     @Column(nullable = false)
     private LocalDate endDate;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PerformanceStatusEnum performanceStatus;
 

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/TimeTable.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/TimeTable.java
@@ -1,6 +1,7 @@
 package com.culture_ticket.client.performance.domain.model;
 
 import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableCreateRequestDto;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -16,7 +17,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
 @Table(name = "p_time_table")
@@ -24,7 +24,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class TimeTable {
+public class TimeTable extends BaseEntity{
 
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
@@ -32,22 +32,36 @@ public class TimeTable {
 
   private UUID performanceId;
   private LocalDate date;
-  @DateTimeFormat(pattern = "HH:mm")
+  @Column(columnDefinition = "TIME(0)")
   private LocalTime startTime;
-  @DateTimeFormat(pattern = "HH:mm")
+  @Column(columnDefinition = "TIME(0)")
   private LocalTime endTime;
 
   @Enumerated(EnumType.STRING)
   private TimeTableStatus timeTableStatus;
 
-  public static TimeTable from(TimeTableCreateRequestDto requestDto){
-    return builder()
+  public static TimeTable of(TimeTableCreateRequestDto requestDto, String username){
+    TimeTable timeTable = builder()
         .performanceId(requestDto.getPerformanceId())
         .date(requestDto.getDate())
         .startTime(requestDto.getStartTime())
         .endTime(requestDto.getEndTime())
         .timeTableStatus(TimeTableStatus.AVAILABLE)
         .build();
+    timeTable.createdBy(username);
+    return timeTable;
   }
 
+  public void updateStatus(TimeTableStatus status, String username){
+    this.timeTableStatus = status;
+    updatedBy(username);
+  }
+
+  public void deleted(String username) {
+    softDeletedBy(username);
+  }
+
+  public void restore(String username) {
+    restoreBy(username);
+  }
 }

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/TimeTable.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/TimeTable.java
@@ -1,0 +1,53 @@
+package com.culture_ticket.client.performance.domain.model;
+
+import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableCreateRequestDto;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Entity
+@Table(name = "p_time_table")
+@Builder(access = AccessLevel.PROTECTED)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeTable {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+
+  private UUID performanceId;
+  private LocalDate date;
+  @DateTimeFormat(pattern = "HH:mm")
+  private LocalTime startTime;
+  @DateTimeFormat(pattern = "HH:mm")
+  private LocalTime endTime;
+
+  @Enumerated(EnumType.STRING)
+  private TimeTableStatus timeTableStatus;
+
+  public static TimeTable from(TimeTableCreateRequestDto requestDto){
+    return builder()
+        .performanceId(requestDto.getPerformanceId())
+        .date(requestDto.getDate())
+        .startTime(requestDto.getStartTime())
+        .endTime(requestDto.getEndTime())
+        .timeTableStatus(TimeTableStatus.AVAILABLE)
+        .build();
+  }
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/TimeTableStatus.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/TimeTableStatus.java
@@ -1,0 +1,12 @@
+package com.culture_ticket.client.performance.domain.model;
+
+import lombok.Getter;
+
+@Getter
+public enum TimeTableStatus {
+
+  SOLD_OUT,
+  UNAVAILABLE,
+  AVAILABLE
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepository.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepository.java
@@ -1,0 +1,9 @@
+package com.culture_ticket.client.performance.domain.repository;
+
+import com.culture_ticket.client.performance.domain.model.TimeTable;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TimeTableRepository extends JpaRepository<TimeTable, UUID>, TimeTableRepositoryCustom {
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepositoryCustom.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.culture_ticket.client.performance.domain.repository;
+
+import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableSearchRequestDto;
+import com.culture_ticket.client.performance.application.dto.responseDto.TimeTableSearchResponseDto;
+import java.util.List;
+
+public interface TimeTableRepositoryCustom {
+
+  List<TimeTableSearchResponseDto> searchTimeTable(TimeTableSearchRequestDto timeTableSearchRequestDto);
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepositoryCustomImpl.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepositoryCustomImpl.java
@@ -1,0 +1,47 @@
+package com.culture_ticket.client.performance.domain.repository;
+
+import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableSearchRequestDto;
+import com.culture_ticket.client.performance.application.dto.responseDto.TimeTableSearchResponseDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+import static com.culture_ticket.client.performance.domain.model.QTimeTable.timeTable;
+
+@RequiredArgsConstructor
+public class TimeTableRepositoryCustomImpl implements TimeTableRepositoryCustom{
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  @Override
+  public List<TimeTableSearchResponseDto> searchTimeTable(
+      TimeTableSearchRequestDto requestDto) {
+    return jpaQueryFactory
+        .select(Projections.constructor(
+            TimeTableSearchResponseDto.class,
+            timeTable.date,
+            timeTable.startTime,
+            timeTable.endTime,
+            timeTable.timeTableStatus
+        ))
+        .from(timeTable)
+        .where(
+            // 공연 아이디가 같은지 (필수, 없으면 모든 공연의 모든 타임 테이블 조회)
+            requestDto.getPerformanceId() != null ? timeTable.performanceId.eq(requestDto.getPerformanceId()) : null,
+            // 날짜가 같은지 (날짜 선택 시 해당 날짜만. 선택 안 할 시 해당 공연의 모든 타임 테이블)
+            requestDto.getDate() != null ? timeTable.date.eq(requestDto.getDate()) : null,
+            // 시작 시간 (좌석 관련 정보 연동 시 필요. 아직은 필요 x)
+            requestDto.getStartTime() != null ? timeTable.startTime.eq(requestDto.getStartTime()) : null,
+            // 종료 시간 (좌석 관련 정보 연동 시 필요. 아직은 필요 x)
+            requestDto.getEndTime() != null ? timeTable.endTime.eq(requestDto.getEndTime()) : null,
+            // 타임 테이블 상태
+            requestDto.getTimeTableStatus() != null ? timeTable.timeTableStatus.eq(requestDto.getTimeTableStatus()) : null
+        )
+        .orderBy(
+            timeTable.date.asc(),
+            timeTable.startTime.asc()
+        )
+        .fetch();
+  }
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepositoryCustomImpl.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepositoryCustomImpl.java
@@ -36,7 +36,9 @@ public class TimeTableRepositoryCustomImpl implements TimeTableRepositoryCustom{
             // 종료 시간 (좌석 관련 정보 연동 시 필요. 아직은 필요 x)
             requestDto.getEndTime() != null ? timeTable.endTime.eq(requestDto.getEndTime()) : null,
             // 타임 테이블 상태
-            requestDto.getTimeTableStatus() != null ? timeTable.timeTableStatus.eq(requestDto.getTimeTableStatus()) : null
+            requestDto.getTimeTableStatus() != null ? timeTable.timeTableStatus.eq(requestDto.getTimeTableStatus()) : null,
+            // 삭제되지 않은 테이블만
+            timeTable.isDeleted.eq(false)
         )
         .orderBy(
             timeTable.date.asc(),

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/PerformanceController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/PerformanceController.java
@@ -6,6 +6,7 @@ import com.culture_ticket.client.performance.application.dto.requestDto.UpdatePe
 import com.culture_ticket.client.performance.application.dto.requestDto.UpdatePerformanceStatusRequestDto;
 import com.culture_ticket.client.performance.application.dto.responseDto.PerformanceResponseDto;
 import com.culture_ticket.client.performance.application.service.PerformanceService;
+import com.culture_ticket.client.performance.application.service.TimeTableService;
 import com.culture_ticket.client.performance.common.ResponseDataDto;
 import com.culture_ticket.client.performance.common.ResponseMessageDto;
 import com.culture_ticket.client.performance.common.ResponseStatus;
@@ -23,6 +24,7 @@ import java.util.UUID;
 public class PerformanceController {
 
     private final PerformanceService performanceService;
+    private final TimeTableService timeTableService;
 
     // 공연 생성
     @PostMapping

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/TimeTableController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/TimeTableController.java
@@ -43,10 +43,9 @@ public class TimeTableController {
   // 검색
   @GetMapping
   public ResponseDataDto<List<TimeTableSearchResponseDto>> searchTimeTables(
-      TimeTableSearchRequestDto requestDto,
-      @RequestHeader(value = "X-User-Role") String role
+      TimeTableSearchRequestDto requestDto
   ) {
-    List<TimeTableSearchResponseDto> responseDtos = timeTableService.searchTimeTables(requestDto, role);
+    List<TimeTableSearchResponseDto> responseDtos = timeTableService.searchTimeTables(requestDto);
     return new ResponseDataDto<>(ResponseStatus.SEARCH_TIME_TABLE_SUCCESS,responseDtos);
   }
 

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/TimeTableController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/TimeTableController.java
@@ -1,0 +1,44 @@
+package com.culture_ticket.client.performance.presentation.controller;
+
+import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableCreateRequestDto;
+import com.culture_ticket.client.performance.application.dto.requestDto.TimeTableSearchRequestDto;
+import com.culture_ticket.client.performance.application.dto.responseDto.TimeTableSearchResponseDto;
+import com.culture_ticket.client.performance.application.service.TimeTableService;
+import com.culture_ticket.client.performance.common.ResponseDataDto;
+import com.culture_ticket.client.performance.common.ResponseMessageDto;
+import com.culture_ticket.client.performance.common.ResponseStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/timetables")
+public class TimeTableController {
+
+  private final TimeTableService timeTableService;
+
+  @PostMapping
+  public ResponseMessageDto createTimeTable(
+      @RequestBody TimeTableCreateRequestDto requestDto,
+      @RequestHeader(value = "X-User-Role") String role
+  ) {
+    timeTableService.createTimeTable(requestDto, role);
+    return new ResponseMessageDto(ResponseStatus.CREATE_TIME_TABLE_SUCCESS);
+  }
+
+  @GetMapping
+  public ResponseDataDto<List<TimeTableSearchResponseDto>> searchTimeTables(
+      TimeTableSearchRequestDto requestDto,
+      @RequestHeader(value = "X-User-Role") String role
+  ) {
+    List<TimeTableSearchResponseDto> responseDtos = timeTableService.searchTimeTables(requestDto, role);
+    return new ResponseDataDto<>(ResponseStatus.SEARCH_TIME_TABLE_SUCCESS,responseDtos);
+  }
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/TimeTableController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/TimeTableController.java
@@ -7,10 +7,16 @@ import com.culture_ticket.client.performance.application.service.TimeTableServic
 import com.culture_ticket.client.performance.common.ResponseDataDto;
 import com.culture_ticket.client.performance.common.ResponseMessageDto;
 import com.culture_ticket.client.performance.common.ResponseStatus;
+import com.culture_ticket.client.performance.domain.model.TimeTableStatus;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,15 +29,18 @@ public class TimeTableController {
 
   private final TimeTableService timeTableService;
 
+  // 생성
   @PostMapping
   public ResponseMessageDto createTimeTable(
-      @RequestBody TimeTableCreateRequestDto requestDto,
-      @RequestHeader(value = "X-User-Role") String role
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestBody TimeTableCreateRequestDto requestDto
   ) {
-    timeTableService.createTimeTable(requestDto, role);
+    timeTableService.createTimeTable(requestDto, username, role);
     return new ResponseMessageDto(ResponseStatus.CREATE_TIME_TABLE_SUCCESS);
   }
 
+  // 검색
   @GetMapping
   public ResponseDataDto<List<TimeTableSearchResponseDto>> searchTimeTables(
       TimeTableSearchRequestDto requestDto,
@@ -41,4 +50,37 @@ public class TimeTableController {
     return new ResponseDataDto<>(ResponseStatus.SEARCH_TIME_TABLE_SUCCESS,responseDtos);
   }
 
+  // 상태 수정
+  @PutMapping("/{timeTableId}")
+  public ResponseMessageDto updateTimeTableStatus(
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestHeader(value = "X-User-Role") String role,
+      @PathVariable UUID timeTableId,
+      @RequestBody TimeTableStatus timeTableStatus
+  ){
+    timeTableService.updateTimeTableStatus(timeTableId, timeTableStatus, username, role);
+    return new ResponseMessageDto(ResponseStatus.UPDATE_TIMETABLE_STATUS_SUCCESS);
+  }
+
+  // 삭제
+  @DeleteMapping("/{timeTableId}")
+  public ResponseMessageDto deleteTimeTable(
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestHeader(value = "X-User-Role") String role,
+      @PathVariable UUID timeTableId
+  ){
+    timeTableService.deleteTimeTable(timeTableId, username, role);
+    return new ResponseMessageDto(ResponseStatus.DELETE_TIMETABLE_SUCCESS);
+  }
+
+  // 복구
+  @PatchMapping("/{timeTableId}")
+  public ResponseMessageDto restoreTimeTable(
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestHeader(value = "X-User-Role") String role,
+      @PathVariable UUID timeTableId
+  ){
+    timeTableService.restoreTimeTable(timeTableId, username, role);
+    return new ResponseMessageDto(ResponseStatus.RESTORE_TIMETABLE_SUCCESS);
+  }
 }

--- a/com.culture-ticket.client.performance/src/test/java/com/culture_ticket/client/performance/PerformanceApplicationTests.java
+++ b/com.culture-ticket.client.performance/src/test/java/com/culture_ticket/client/performance/PerformanceApplicationTests.java
@@ -1,13 +1,13 @@
-package com.culture_ticket.client.performance;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
-class PerformanceApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
-}
+//package com.culture_ticket.client.performance;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//@SpringBootTest
+//class PerformanceApplicationTests {
+//
+//	@Test
+//	void contextLoads() {
+//	}
+//
+//}

--- a/com.culture-ticket.client.user/src/main/java/com/culture_ticket/client/user/application/dto/request/SignupRequestDto.java
+++ b/com.culture-ticket.client.user/src/main/java/com/culture_ticket/client/user/application/dto/request/SignupRequestDto.java
@@ -31,9 +31,6 @@ public class SignupRequestDto {
   @DateTimeFormat
   private LocalDate birth;
 
-  @Pattern(
-      regexp = "ADMIN|USER"
-  )
   private Role role;
 
   private String adminCode;


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feate/#15-timetable -> dev
### 이슈
- resolves: #15 
### Description
- 우선 도메인 단일로 CRUD, Search, Restore를 구현했습니다.
- 이후 Seat까지 구현한 후, 리팩토링을 통해 performance 생성에 TimeTable, Seat의 생성을 병합할 예정입니다.
### To Reviewers
- 리뷰받고 싶은 부분에 대해 작성