### PR TITLE
[Feat]: Seat CRUD, Restore 기능 구현

### DIFF
--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/CreateSeatRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/CreateSeatRequestDto.java
@@ -1,0 +1,12 @@
+package com.culture_ticket.client.performance.application.dto.requestDto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateSeatRequestDto {
+
+  private String seatClass;
+  private Long price;
+  private Integer count;
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/PerformanceCreateRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/PerformanceCreateRequestDto.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class PerformanceCreateRequestDto {
     private String category;

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/PerformanceDomainCreateRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/PerformanceDomainCreateRequestDto.java
@@ -1,0 +1,13 @@
+package com.culture_ticket.client.performance.application.dto.requestDto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PerformanceDomainCreateRequestDto {
+
+  private PerformanceCreateRequestDto performanceCreateRequestDto;
+  private TimeTableCreateRequestDto timeTableCreateRequestDto;
+  private List<SeatCreateRequestDto> seatCreateRequestDtos;
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/SeatCreateRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/SeatCreateRequestDto.java
@@ -3,7 +3,7 @@ package com.culture_ticket.client.performance.application.dto.requestDto;
 import lombok.Getter;
 
 @Getter
-public class CreateSeatRequestDto {
+public class SeatCreateRequestDto {
 
   private String seatClass;
   private Long price;

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/TimeTableCreateRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/TimeTableCreateRequestDto.java
@@ -3,12 +3,10 @@ package com.culture_ticket.client.performance.application.dto.requestDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.UUID;
 import lombok.Getter;
 
 @Getter
 public class TimeTableCreateRequestDto {
-  private UUID performanceId;
   private LocalDate date;
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
   private LocalTime startTime;

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/UpdateSeatPriceRequestDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/requestDto/UpdateSeatPriceRequestDto.java
@@ -1,0 +1,11 @@
+package com.culture_ticket.client.performance.application.dto.requestDto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateSeatPriceRequestDto {
+
+  private String seatClass;
+  private Long newPrice;
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/responseDto/SeatInfoResponseDto.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/dto/responseDto/SeatInfoResponseDto.java
@@ -1,0 +1,27 @@
+package com.culture_ticket.client.performance.application.dto.responseDto;
+
+import com.culture_ticket.client.performance.domain.model.Seat;
+import com.culture_ticket.client.performance.domain.model.SeatStatus;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SeatInfoResponseDto {
+
+  private UUID seatId;
+  private String seatClass;
+  private Integer seatNumber;
+  private Long seatPrice;
+  private SeatStatus seatStatus;
+
+  public SeatInfoResponseDto(Seat seat){
+    this.seatId = seat.getId();
+    this.seatClass = seat.getSeatClass();
+    this.seatNumber = seat.getSeatNumber();
+    this.seatPrice = seat.getSeatPrice();
+    this.seatStatus = seat.getSeatStatus();
+  }
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/PerformanceService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/PerformanceService.java
@@ -31,7 +31,7 @@ public class PerformanceService {
 
     // 공연 생성
     @Transactional
-    public void createPerformance(String role, String username, PerformanceCreateRequestDto performanceCreateRequestDto) {
+    public UUID createPerformance(String username, String role, PerformanceCreateRequestDto performanceCreateRequestDto) {
         validateRoleADMIN(role);
         checkDuplicateTitle(performanceCreateRequestDto.getTitle());
 
@@ -41,6 +41,7 @@ public class PerformanceService {
         Performance performance = Performance.createPerformance(performanceCreateRequestDto, category);
         performance.setCreatedBy(username);
         performanceRepository.save(performance);
+        return performance.getId();
     }
 
     // 공연 단일 조회

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/SeatService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/SeatService.java
@@ -1,5 +1,85 @@
 package com.culture_ticket.client.performance.application.service;
 
+import com.culture_ticket.client.performance.application.dto.requestDto.CreateSeatRequestDto;
+import com.culture_ticket.client.performance.application.dto.requestDto.UpdateSeatPriceRequestDto;
+import com.culture_ticket.client.performance.application.dto.responseDto.SeatInfoResponseDto;
+import com.culture_ticket.client.performance.common.CustomException;
+import com.culture_ticket.client.performance.common.ErrorType;
+import com.culture_ticket.client.performance.common.util.RoleValidator;
+import com.culture_ticket.client.performance.domain.model.Seat;
+import com.culture_ticket.client.performance.domain.model.SeatStatus;
+import com.culture_ticket.client.performance.domain.model.TimeTable;
+import com.culture_ticket.client.performance.domain.repository.PerformanceRepository;
+import com.culture_ticket.client.performance.domain.repository.SeatRepository;
+import com.culture_ticket.client.performance.domain.repository.TimeTableRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class SeatService {
 
+  private final PerformanceRepository performanceRepository;
+  private final TimeTableRepository timeTableRepository;
+  private final SeatRepository seatRepository;
+
+  public void createSeats(UUID timeTableId, List<CreateSeatRequestDto> requestDtos, String username, String role) {
+    RoleValidator.validateIsAdmin(role);
+    TimeTable timeTable = timeTableRepository.findById(timeTableId).orElseThrow(
+        () -> new CustomException(ErrorType.TIMETABLE_NOT_FOUND)
+    );
+    for (CreateSeatRequestDto seatCreateRequestDto : requestDtos) {
+      List<Seat> seats = Seat.of(timeTable, seatCreateRequestDto, username);
+      seatRepository.saveAll(seats);
+    }
+  }
+
+  public List<SeatInfoResponseDto> getSeats(UUID performanceId, UUID timeTableId) {
+    performanceRepository.findById(performanceId).orElseThrow(
+        () -> new CustomException(ErrorType.PERFORMANCE_NOT_FOUND)
+    );
+    TimeTable timeTable = timeTableRepository.findById(timeTableId).orElseThrow(
+        () -> new CustomException(ErrorType.TIMETABLE_NOT_FOUND)
+    );
+    List<Seat> seats = seatRepository.findAllByTimeTable(timeTable);
+    return seats.stream().map(SeatInfoResponseDto::new).toList();
+  }
+
+  public void updateSeatsStatus(String username, SeatStatus seatStatus, List<UUID> seatIds) {
+    List<Seat> seats = seatRepository.findAllById(seatIds);
+    for (Seat seat : seats) {
+      seat.updateStatus(username, seatStatus);
+    }
+  }
+
+  public void deleteSeats(List<UUID> seatIds, String username, String role) {
+    RoleValidator.validateIsAdmin(role);
+    List<Seat> seats = seatRepository.findAllById(seatIds);
+    for (Seat seat : seats) {
+      seat.deleted(username);
+    }
+  }
+
+  public void restoreSeats(List<UUID> seatIds, String username, String role) {
+    RoleValidator.validateIsAdmin(role);
+    List<Seat> seats = seatRepository.findAllById(seatIds);
+    for (Seat seat : seats) {
+      seat.restore(username);
+    }
+  }
+
+  public void updateSeatsPrice(String username, String role, UUID timeTableId, UpdateSeatPriceRequestDto requestDto) {
+    RoleValidator.validateIsAdmin(role);
+    TimeTable timeTable = timeTableRepository.findById(timeTableId).orElseThrow(
+        () -> new CustomException(ErrorType.TIMETABLE_NOT_FOUND)
+    );
+    List<Seat> seats = seatRepository.findAllByTimeTableAndSeatClass(timeTable, requestDto.getSeatClass());
+    for (Seat seat : seats) {
+      seat.updatePrice(requestDto.getNewPrice(), username);
+    }
+  }
 }

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/SeatService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/SeatService.java
@@ -1,6 +1,6 @@
 package com.culture_ticket.client.performance.application.service;
 
-import com.culture_ticket.client.performance.application.dto.requestDto.CreateSeatRequestDto;
+import com.culture_ticket.client.performance.application.dto.requestDto.SeatCreateRequestDto;
 import com.culture_ticket.client.performance.application.dto.requestDto.UpdateSeatPriceRequestDto;
 import com.culture_ticket.client.performance.application.dto.responseDto.SeatInfoResponseDto;
 import com.culture_ticket.client.performance.common.CustomException;
@@ -27,12 +27,12 @@ public class SeatService {
   private final TimeTableRepository timeTableRepository;
   private final SeatRepository seatRepository;
 
-  public void createSeats(UUID timeTableId, List<CreateSeatRequestDto> requestDtos, String username, String role) {
+  public void createSeats(String username, String role, UUID timeTableId, List<SeatCreateRequestDto> requestDtos) {
     RoleValidator.validateIsAdmin(role);
     TimeTable timeTable = timeTableRepository.findById(timeTableId).orElseThrow(
         () -> new CustomException(ErrorType.TIMETABLE_NOT_FOUND)
     );
-    for (CreateSeatRequestDto seatCreateRequestDto : requestDtos) {
+    for (SeatCreateRequestDto seatCreateRequestDto : requestDtos) {
       List<Seat> seats = Seat.of(timeTable, seatCreateRequestDto, username);
       seatRepository.saveAll(seats);
     }

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/TimeTableService.java
@@ -6,6 +6,7 @@ import com.culture_ticket.client.performance.application.dto.responseDto.TimeTab
 import com.culture_ticket.client.performance.common.CustomException;
 import com.culture_ticket.client.performance.common.ErrorType;
 import com.culture_ticket.client.performance.common.util.RoleValidator;
+import com.culture_ticket.client.performance.domain.model.Performance;
 import com.culture_ticket.client.performance.domain.model.TimeTable;
 import com.culture_ticket.client.performance.domain.model.TimeTableStatus;
 import com.culture_ticket.client.performance.domain.repository.PerformanceRepository;
@@ -24,12 +25,13 @@ public class TimeTableService {
   private final TimeTableRepository timeTableRepository;
   private final PerformanceRepository performanceRepository;
 
-  public void createTimeTable(TimeTableCreateRequestDto requestDto, String username, String role) {
+  public UUID createTimeTable(String username, String role, UUID performanceId, TimeTableCreateRequestDto requestDto) {
     RoleValidator.validateIsAdmin(role);
-    performanceRepository.findById(requestDto.getPerformanceId()).orElseThrow(
+    Performance performance = performanceRepository.findById(performanceId).orElseThrow(
         () -> new CustomException(ErrorType.PERFORMANCE_NOT_FOUND)
     );
-    timeTableRepository.save(TimeTable.of(requestDto, username));
+    TimeTable timeTable = timeTableRepository.save(TimeTable.of(username, performance, requestDto));
+    return timeTable.getId();
   }
 
   public List<TimeTableSearchResponseDto> searchTimeTables(TimeTableSearchRequestDto requestDto) {

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
@@ -35,6 +35,7 @@ public enum ResponseStatus {
     UPDATE_PERFORMANCE_STATUS_SUCCESS(HttpStatus.OK, "공연 상태 수정에 성공했습니다."),
     UPDATE_PERFORMANCE(HttpStatus.OK, "공연 수정에 성공했습니다."),
     DELETE_PERFORMANCE_SUCCESS(HttpStatus.OK, "공연 삭제에 성공했습니다."),
+    CREATE_PERFORMANCE_DOMAIN_SUCCESS(HttpStatus.CREATED, "공연 도메인 생성에 성공했습니다."),
 
     // timetable
     CREATE_TIME_TABLE_SUCCESS(HttpStatus.OK, "타임테이블 생성에 성공하였습니다."),

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
@@ -41,7 +41,15 @@ public enum ResponseStatus {
     SEARCH_TIME_TABLE_SUCCESS(HttpStatus.OK, "타임테이블 검색에 성공했습니다."),
     UPDATE_TIMETABLE_STATUS_SUCCESS(HttpStatus.OK, "타임테이블 상태 변경에 성공했습니다."),
     DELETE_TIMETABLE_SUCCESS(HttpStatus.OK, "타임테이블 삭제에 성공했습니다."),
-    RESTORE_TIMETABLE_SUCCESS(HttpStatus.OK, "타임테이블 복원에 성공했습니다.");
+    RESTORE_TIMETABLE_SUCCESS(HttpStatus.OK, "타임테이블 복원에 성공했습니다."),
+
+    // Seat
+    CREATE_SEAT_SUCCESS(HttpStatus.CREATED,"좌석 생성에 성공했습니다."),
+    GET_SEAT_INFO_SUCCESS(HttpStatus.OK, "좌석 목록 조회에 성공했습니다."),
+    UPDATE_SEAT_STATUS_SUCCESS(HttpStatus.OK, "좌석 상태 변경에 성공했습니다."),
+    DELETE_SEAT_SUCCESS(HttpStatus.OK,"좌석 삭제에 성공했습니다."),
+    RESTORE_SEAT_SUCCESS(HttpStatus.OK, "좌석 복구에 성공했습니다."),
+    UPDATE_SEAT_PRICE_SUCCESS(HttpStatus.OK,"좌석 가격 변경에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/Seat.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/Seat.java
@@ -1,6 +1,6 @@
 package com.culture_ticket.client.performance.domain.model;
 
-import com.culture_ticket.client.performance.application.dto.requestDto.CreateSeatRequestDto;
+import com.culture_ticket.client.performance.application.dto.requestDto.SeatCreateRequestDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -39,7 +39,7 @@ public class Seat extends BaseEntity{
   @ManyToOne(fetch = FetchType.LAZY)
   private TimeTable timeTable;
 
-  public static List<Seat> of(TimeTable timeTable, CreateSeatRequestDto requestDto, String username){
+  public static List<Seat> of(TimeTable timeTable, SeatCreateRequestDto requestDto, String username){
     List<Seat> seats = new ArrayList<>();
     for (int seatNumber = 1; seatNumber <= requestDto.getCount(); seatNumber++) {
       Seat seat = builder()

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/Seat.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/Seat.java
@@ -1,0 +1,75 @@
+package com.culture_ticket.client.performance.domain.model;
+
+import com.culture_ticket.client.performance.application.dto.requestDto.CreateSeatRequestDto;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_seat")
+@Getter
+@Builder(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@AllArgsConstructor
+public class Seat extends BaseEntity{
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
+  private String seatClass;
+  private Integer seatNumber;
+  private Long seatPrice;
+  @Enumerated(EnumType.STRING)
+  private SeatStatus seatStatus;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private TimeTable timeTable;
+
+  public static List<Seat> of(TimeTable timeTable, CreateSeatRequestDto requestDto, String username){
+    List<Seat> seats = new ArrayList<>();
+    for (int seatNumber = 1; seatNumber <= requestDto.getCount(); seatNumber++) {
+      Seat seat = builder()
+          .seatClass(requestDto.getSeatClass())
+          .seatNumber(seatNumber)
+          .seatPrice(requestDto.getPrice())
+          .seatStatus(SeatStatus.AVAILABLE)
+          .timeTable(timeTable)
+          .build();
+      seat.createdBy(username);
+      seats.add(seat);
+    }
+    return seats;
+  }
+
+  public void updateStatus(String username, SeatStatus seatStatus) {
+    updatedBy(username);
+    this.seatStatus = seatStatus;
+  }
+
+  public void deleted(String username) {
+    softDeletedBy(username);
+  }
+
+  public void restore(String username) {
+    restoreBy(username);
+  }
+
+  public void updatePrice(Long newPrice, String username) {
+    this.seatPrice = newPrice;
+    updatedBy(username);
+  }
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/SeatStatus.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/SeatStatus.java
@@ -1,0 +1,10 @@
+package com.culture_ticket.client.performance.domain.model;
+
+import lombok.Getter;
+
+@Getter
+public enum SeatStatus {
+
+  AVAILABLE, UNAVAILABLE
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/TimeTable.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/model/TimeTable.java
@@ -5,9 +5,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -30,23 +32,23 @@ public class TimeTable extends BaseEntity{
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
-  private UUID performanceId;
   private LocalDate date;
   @Column(columnDefinition = "TIME(0)")
   private LocalTime startTime;
   @Column(columnDefinition = "TIME(0)")
   private LocalTime endTime;
-
   @Enumerated(EnumType.STRING)
   private TimeTableStatus timeTableStatus;
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Performance performance;
 
-  public static TimeTable of(TimeTableCreateRequestDto requestDto, String username){
+  public static TimeTable of(String username, Performance performance, TimeTableCreateRequestDto requestDto){
     TimeTable timeTable = builder()
-        .performanceId(requestDto.getPerformanceId())
         .date(requestDto.getDate())
         .startTime(requestDto.getStartTime())
         .endTime(requestDto.getEndTime())
         .timeTableStatus(TimeTableStatus.AVAILABLE)
+        .performance(performance)
         .build();
     timeTable.createdBy(username);
     return timeTable;

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/SeatRepository.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/SeatRepository.java
@@ -1,0 +1,14 @@
+package com.culture_ticket.client.performance.domain.repository;
+
+import com.culture_ticket.client.performance.domain.model.Seat;
+import com.culture_ticket.client.performance.domain.model.TimeTable;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatRepository extends JpaRepository<Seat, UUID> {
+
+  List<Seat> findAllByTimeTable(TimeTable timeTable);
+  List<Seat> findAllByTimeTableAndSeatClass(TimeTable timeTable, String seatClass);
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepositoryCustomImpl.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/repository/TimeTableRepositoryCustomImpl.java
@@ -28,7 +28,7 @@ public class TimeTableRepositoryCustomImpl implements TimeTableRepositoryCustom{
         .from(timeTable)
         .where(
             // 공연 아이디가 같은지 (필수, 없으면 모든 공연의 모든 타임 테이블 조회)
-            requestDto.getPerformanceId() != null ? timeTable.performanceId.eq(requestDto.getPerformanceId()) : null,
+            requestDto.getPerformanceId() != null ? timeTable.performance.id.eq(requestDto.getPerformanceId()) : null,
             // 날짜가 같은지 (날짜 선택 시 해당 날짜만. 선택 안 할 시 해당 공연의 모든 타임 테이블)
             requestDto.getDate() != null ? timeTable.date.eq(requestDto.getDate()) : null,
             // 시작 시간 (좌석 관련 정보 연동 시 필요. 아직은 필요 x)

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/service/PerformanceDomainService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/domain/service/PerformanceDomainService.java
@@ -1,0 +1,26 @@
+package com.culture_ticket.client.performance.domain.service;
+
+import com.culture_ticket.client.performance.application.dto.requestDto.PerformanceDomainCreateRequestDto;
+import com.culture_ticket.client.performance.application.service.PerformanceService;
+import com.culture_ticket.client.performance.application.service.SeatService;
+import com.culture_ticket.client.performance.application.service.TimeTableService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PerformanceDomainService {
+
+  private final PerformanceService performanceService;
+  private final TimeTableService timeTableService;
+  private final SeatService seatService;
+
+  public void createPerformanceDomain(String username, String role, PerformanceDomainCreateRequestDto performanceDomainCreateRequestDto){
+    UUID performanceId = performanceService.createPerformance(username, role, performanceDomainCreateRequestDto.getPerformanceCreateRequestDto());
+    UUID timeTableId = timeTableService.createTimeTable(username, role, performanceId, performanceDomainCreateRequestDto.getTimeTableCreateRequestDto());
+    seatService.createSeats(username, role, timeTableId, performanceDomainCreateRequestDto.getSeatCreateRequestDtos());
+  }
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/PerformanceController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/PerformanceController.java
@@ -2,91 +2,116 @@ package com.culture_ticket.client.performance.presentation.controller;
 
 
 import com.culture_ticket.client.performance.application.dto.requestDto.PerformanceCreateRequestDto;
+import com.culture_ticket.client.performance.application.dto.requestDto.PerformanceDomainCreateRequestDto;
 import com.culture_ticket.client.performance.application.dto.requestDto.UpdatePerformanceRequestDto;
 import com.culture_ticket.client.performance.application.dto.requestDto.UpdatePerformanceStatusRequestDto;
 import com.culture_ticket.client.performance.application.dto.responseDto.PerformanceResponseDto;
 import com.culture_ticket.client.performance.application.service.PerformanceService;
-import com.culture_ticket.client.performance.application.service.TimeTableService;
 import com.culture_ticket.client.performance.common.ResponseDataDto;
 import com.culture_ticket.client.performance.common.ResponseMessageDto;
 import com.culture_ticket.client.performance.common.ResponseStatus;
+import com.culture_ticket.client.performance.domain.service.PerformanceDomainService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/performances")
 public class PerformanceController {
 
-    private final PerformanceService performanceService;
-    private final TimeTableService timeTableService;
+  private final PerformanceService performanceService;
+  private final PerformanceDomainService performanceDomainService;
 
-    // 공연 생성
-    @PostMapping
-    public ResponseMessageDto createPerformance(
-            @RequestBody PerformanceCreateRequestDto performanceCreateRequestDto,
-            @RequestHeader(value = "X-User-Role") String role,
-            @RequestHeader(value = "X-User-Name") String username
-    ) {
-        performanceService.createPerformance(role, username, performanceCreateRequestDto);
-        return new ResponseMessageDto(ResponseStatus.CREATE_PERFORMANCE_SUCCESS);
-    }
+  // 공연 도메인 생성
+  @PostMapping("/domain")
+  public ResponseMessageDto createPerformanceDomain(
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestBody PerformanceDomainCreateRequestDto performanceDomainCreateRequestDto
+  ) {
+    performanceDomainService.createPerformanceDomain(username, role, performanceDomainCreateRequestDto);
+    return new ResponseMessageDto(ResponseStatus.CREATE_PERFORMANCE_DOMAIN_SUCCESS);
+  }
 
-    // 공연 단일 조회 (performanceId)
-    @GetMapping("/info/{performanceId}")
-    public ResponseDataDto<PerformanceResponseDto> getPerformance(@PathVariable UUID performanceId) {
-        PerformanceResponseDto performanceResponseDto = performanceService.getPerformance(performanceId);
-        return new ResponseDataDto<>(ResponseStatus.GET_PERFORMANCE_SUCCESS, performanceResponseDto);
-    }
+  // 공연 생성
+  @PostMapping
+  public ResponseMessageDto createPerformance(
+      @RequestBody PerformanceCreateRequestDto performanceCreateRequestDto,
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestHeader(value = "X-User-Role") String role
+  ) {
+    performanceService.createPerformance(username, role, performanceCreateRequestDto);
+    return new ResponseMessageDto(ResponseStatus.CREATE_PERFORMANCE_SUCCESS);
+  }
 
-    // 공연 목록 조회 & 검색 (title)
-    @GetMapping("/info")
-    public ResponseDataDto<Page<PerformanceResponseDto>> getPerformances(
-            @RequestParam(value = "condition", required = false) String condition,
-            @RequestParam(value = "keyword", required = false) String keyword,
-            @PageableDefault Pageable pageable
-    ) {
-        Page<PerformanceResponseDto> performances = performanceService.getPerformances(condition, keyword, pageable);
-        return new ResponseDataDto<>(ResponseStatus.GET_PERFORMANCE_SUCCESS, performances);
-    }
+  // 공연 단일 조회 (performanceId)
+  @GetMapping("/info/{performanceId}")
+  public ResponseDataDto<PerformanceResponseDto> getPerformance(@PathVariable UUID performanceId) {
+    PerformanceResponseDto performanceResponseDto = performanceService.getPerformance(
+        performanceId);
+    return new ResponseDataDto<>(ResponseStatus.GET_PERFORMANCE_SUCCESS, performanceResponseDto);
+  }
 
-    // 공연 상태 수정
-    @PatchMapping("/{performanceId}")
-    public ResponseMessageDto updatePerformanceStatus(
-            @PathVariable UUID performanceId,
-            @RequestBody UpdatePerformanceStatusRequestDto updatePerformanceStatusRequestDto,
-            @RequestHeader(value = "X-User-Role") String role,
-            @RequestHeader(value = "X-User-Name") String username
-    ) {
-        performanceService.updatePerformanceStatus(role, username, performanceId, updatePerformanceStatusRequestDto);
-        return new ResponseMessageDto(ResponseStatus.UPDATE_PERFORMANCE_STATUS_SUCCESS);
-    }
+  // 공연 목록 조회 & 검색 (title)
+  @GetMapping("/info")
+  public ResponseDataDto<Page<PerformanceResponseDto>> getPerformances(
+      @RequestParam(value = "condition", required = false) String condition,
+      @RequestParam(value = "keyword", required = false) String keyword,
+      @PageableDefault Pageable pageable
+  ) {
+    Page<PerformanceResponseDto> performances = performanceService.getPerformances(condition,
+        keyword, pageable);
+    return new ResponseDataDto<>(ResponseStatus.GET_PERFORMANCE_SUCCESS, performances);
+  }
 
-    // 공연 수정
-    @PutMapping("/{performanceId}")
-    public ResponseMessageDto updatePerformance(
-            @PathVariable UUID performanceId,
-            @RequestBody UpdatePerformanceRequestDto updatePerformanceRequestDto,
-            @RequestHeader(value = "X-User-Role") String role,
-            @RequestHeader(value = "X-User-Name") String username
-    ) {
-        performanceService.updatePerformance(role, username, performanceId, updatePerformanceRequestDto);
-        return new ResponseMessageDto(ResponseStatus.UPDATE_PERFORMANCE);
-    }
+  // 공연 상태 수정
+  @PatchMapping("/{performanceId}")
+  public ResponseMessageDto updatePerformanceStatus(
+      @PathVariable UUID performanceId,
+      @RequestBody UpdatePerformanceStatusRequestDto updatePerformanceStatusRequestDto,
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestHeader(value = "X-User-Name") String username
+  ) {
+    performanceService.updatePerformanceStatus(role, username, performanceId,
+        updatePerformanceStatusRequestDto);
+    return new ResponseMessageDto(ResponseStatus.UPDATE_PERFORMANCE_STATUS_SUCCESS);
+  }
 
-    // 공연 삭제
-    @DeleteMapping("/{performanceId}")
-    public ResponseMessageDto deletePerformance(
-            @PathVariable UUID performanceId,
-            @RequestHeader(value = "X-User-Role") String role,
-            @RequestHeader(value = "X-User-Name") String username
-    ) {
-        performanceService.deletePerformance(role, username, performanceId);
-        return new ResponseMessageDto(ResponseStatus.DELETE_PERFORMANCE_SUCCESS);
-    }
+  // 공연 수정
+  @PutMapping("/{performanceId}")
+  public ResponseMessageDto updatePerformance(
+      @PathVariable UUID performanceId,
+      @RequestBody UpdatePerformanceRequestDto updatePerformanceRequestDto,
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestHeader(value = "X-User-Name") String username
+  ) {
+    performanceService.updatePerformance(role, username, performanceId,
+        updatePerformanceRequestDto);
+    return new ResponseMessageDto(ResponseStatus.UPDATE_PERFORMANCE);
+  }
+
+  // 공연 삭제
+  @DeleteMapping("/{performanceId}")
+  public ResponseMessageDto deletePerformance(
+      @PathVariable UUID performanceId,
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestHeader(value = "X-User-Name") String username
+  ) {
+    performanceService.deletePerformance(role, username, performanceId);
+    return new ResponseMessageDto(ResponseStatus.DELETE_PERFORMANCE_SUCCESS);
+  }
 }

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/SeatController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/SeatController.java
@@ -1,6 +1,6 @@
 package com.culture_ticket.client.performance.presentation.controller;
 
-import com.culture_ticket.client.performance.application.dto.requestDto.CreateSeatRequestDto;
+import com.culture_ticket.client.performance.application.dto.requestDto.SeatCreateRequestDto;
 import com.culture_ticket.client.performance.application.dto.requestDto.UpdateSeatPriceRequestDto;
 import com.culture_ticket.client.performance.application.dto.responseDto.SeatInfoResponseDto;
 import com.culture_ticket.client.performance.application.service.SeatService;
@@ -35,9 +35,9 @@ public class SeatController {
       @RequestHeader(value = "X-User-Role") String role,
       @RequestHeader(value = "X-User-Name") String username,
       @RequestParam(name = "timeTableId") UUID timeTableId,
-      @RequestBody List<CreateSeatRequestDto> requestDtos
+      @RequestBody List<SeatCreateRequestDto> requestDtos
   ) {
-    seatService.createSeats(timeTableId, requestDtos, username, role);
+    seatService.createSeats(username, role, timeTableId, requestDtos);
     return new ResponseMessageDto(ResponseStatus.CREATE_SEAT_SUCCESS);
   }
 

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/SeatController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/SeatController.java
@@ -1,0 +1,100 @@
+package com.culture_ticket.client.performance.presentation.controller;
+
+import com.culture_ticket.client.performance.application.dto.requestDto.CreateSeatRequestDto;
+import com.culture_ticket.client.performance.application.dto.requestDto.UpdateSeatPriceRequestDto;
+import com.culture_ticket.client.performance.application.dto.responseDto.SeatInfoResponseDto;
+import com.culture_ticket.client.performance.application.service.SeatService;
+import com.culture_ticket.client.performance.common.ResponseDataDto;
+import com.culture_ticket.client.performance.common.ResponseMessageDto;
+import com.culture_ticket.client.performance.common.ResponseStatus;
+import com.culture_ticket.client.performance.domain.model.SeatStatus;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/seats")
+public class SeatController {
+
+  private final SeatService seatService;
+
+  // 목록 생성
+  @PostMapping
+  public ResponseMessageDto createSeats(
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestParam(name = "timeTableId") UUID timeTableId,
+      @RequestBody List<CreateSeatRequestDto> requestDtos
+  ) {
+    seatService.createSeats(timeTableId, requestDtos, username, role);
+    return new ResponseMessageDto(ResponseStatus.CREATE_SEAT_SUCCESS);
+  }
+
+  // 목록 조회
+  @GetMapping
+  public ResponseDataDto<List<SeatInfoResponseDto>> getSeats(
+      @RequestParam UUID performanceId,
+      @RequestParam UUID timeTableId
+  ) {
+    List<SeatInfoResponseDto> responseDtos = seatService.getSeats(performanceId, timeTableId);
+    return new ResponseDataDto<>(ResponseStatus.GET_SEAT_INFO_SUCCESS,responseDtos);
+  }
+
+  // 좌석 상태 변경
+  @PatchMapping("/status/{seatStatus}")
+  public ResponseMessageDto updateSeatsStatusAvailable(
+      @RequestHeader(value = "X-User-Name") String username,
+      @PathVariable SeatStatus seatStatus,
+      @RequestBody List<UUID> seatIds
+  ){
+    seatService.updateSeatsStatus(username, seatStatus, seatIds);
+    return new ResponseMessageDto(ResponseStatus.UPDATE_SEAT_STATUS_SUCCESS);
+  }
+
+  //좌석 가격 수정
+  @PatchMapping("/price")
+  public ResponseMessageDto updateSeatsPrice(
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestParam(value = "timeTableId") UUID timeTableId,
+      @RequestBody UpdateSeatPriceRequestDto requestDto
+  ){
+    seatService.updateSeatsPrice(username, role, timeTableId, requestDto);
+    return new ResponseMessageDto(ResponseStatus.UPDATE_SEAT_PRICE_SUCCESS);
+  }
+
+
+  // 삭제
+  @DeleteMapping
+  public ResponseMessageDto deleteSeats(
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestBody List<UUID> seatIds
+  ){
+    seatService.deleteSeats(seatIds, username, role);
+    return new ResponseMessageDto(ResponseStatus.DELETE_SEAT_SUCCESS);
+  }
+
+  // 복구
+  @PatchMapping
+  public ResponseMessageDto restoreSeats(
+      @RequestHeader(value = "X-User-Name") String username,
+      @RequestHeader(value = "X-User-Role") String role,
+      @RequestBody List<UUID> seatIds
+  ){
+    seatService.restoreSeats(seatIds, username, role);
+    return new ResponseMessageDto(ResponseStatus.RESTORE_SEAT_SUCCESS);
+  }
+
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/TimeTableController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/TimeTableController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -34,9 +35,10 @@ public class TimeTableController {
   public ResponseMessageDto createTimeTable(
       @RequestHeader(value = "X-User-Role") String role,
       @RequestHeader(value = "X-User-Name") String username,
+      @RequestParam(value = "performanceId") UUID performanceId,
       @RequestBody TimeTableCreateRequestDto requestDto
   ) {
-    timeTableService.createTimeTable(requestDto, username, role);
+    timeTableService.createTimeTable(username, role, performanceId, requestDto);
     return new ResponseMessageDto(ResponseStatus.CREATE_TIME_TABLE_SUCCESS);
   }
 


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/#16-seat -> dev
### 이슈
- resolves: #16 
### Description
2025-01-08 22:15
- 공연 생성 시 타임테이블, 좌석 동시 생성되도록 기능을 구현했습니다.

2025-01-08 21:00
- 좌석의 경우 좌석 1개에 대해서만 요청이 들어올 경우는 굳이 없을 것 같아 생성,수정,삭제 모두 값을 리스트로 받아오도록 구현했습니다.
- 같은 등급의 좌석을 추가로 더 생성하려는 경우 number가 for 반복문으로 추가되기 때문에 좌석 번호가 중복이 발생할 수 있습니다. 해당 부분은 다음 주 리팩토링 기간에 보완할 예정입니다.
- 공연 생성 시 타임 테이블, 좌석이 같이 생성되도록 하는 부분은 아직 미구현입니다. 현재는 개별로 생성해야 합니다.
- 
### To Reviewers
- 리뷰받고 싶은 부분에 대해 작성