### PR TITLE
Redis를 활용한 실시간 랭킹 기능 구현

### DIFF
--- a/com.culture-ticket.client.coupon/src/main/java/com/culture_ticket/client/coupon/infrastructure/aop/DistributeLockAop.java
+++ b/com.culture-ticket.client.coupon/src/main/java/com/culture_ticket/client/coupon/infrastructure/aop/DistributeLockAop.java
@@ -42,7 +42,7 @@ public class DistributeLockAop {
                 return false;
             }
 
-            log.info("get lock success {}" , key);
+//            log.info("get lock success {}" , key);
             return aopForTransaction.proceed(joinPoint);    // (5)
         } catch (Exception e) {
             Thread.currentThread().interrupt();

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/PerformanceApplication.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/PerformanceApplication.java
@@ -3,9 +3,11 @@ package com.culture_ticket.client.performance;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class PerformanceApplication {
 
 	public static void main(String[] args) {

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/PerformanceService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/PerformanceService.java
@@ -8,27 +8,30 @@ import com.culture_ticket.client.performance.application.dto.requestDto.UpdatePe
 import com.culture_ticket.client.performance.application.dto.responseDto.PerformanceResponseDto;
 import com.culture_ticket.client.performance.common.CustomException;
 import com.culture_ticket.client.performance.common.ErrorType;
+import com.culture_ticket.client.performance.common.util.RedisKeyHelper;
 import com.culture_ticket.client.performance.domain.model.Category;
 import com.culture_ticket.client.performance.domain.model.Performance;
 import com.culture_ticket.client.performance.domain.repository.CategoryRepository;
 import com.culture_ticket.client.performance.domain.repository.PerformanceRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class PerformanceService {
 
     private final PerformanceRepository performanceRepository;
     private final CategoryRepository categoryRepository;
-
-    public PerformanceService(PerformanceRepository performanceRepository, CategoryRepository categoryRepository) {
-        this.performanceRepository = performanceRepository;
-        this.categoryRepository = categoryRepository;
-    }
+    private final RedisTemplate<String, Object> redisTemplate;
 
     // 공연 생성
     @Transactional
@@ -46,11 +49,28 @@ public class PerformanceService {
     }
 
     // 공연 단건 조회
-    @Cacheable(cacheNames = "performanceCache", key = "#performanceId")
     @Transactional(readOnly = true)
     public PerformanceResponseDto getPerformance(UUID performanceId) {
+        // 1. Redis 캐시 키 생성
+        String cacheKey = RedisKeyHelper.getEventDetailCacheKey(performanceId);
+        String rankKey = RedisKeyHelper.getViewRankKey(); // 랭킹 키 생성
+        // 2. 캐시에서 데이터 확인
+        PerformanceResponseDto cachedPerformance = getCachedPerformance(performanceId, cacheKey, rankKey);
+        if (cachedPerformance != null) return cachedPerformance;
+        // 5. 캐시 데이터가 없으면 DB에서 조회
         Performance performance = findPerformanceById(performanceId);
+        // 6. 조회 결과를 Redis 캐시에 저장
+        PerformanceResponseDto performanceResponseDto = new PerformanceResponseDto(performance);
+        redisTemplate.opsForValue().set(cacheKey, performanceResponseDto, Duration.ofHours(24)); // TTL 설정
         return new PerformanceResponseDto(performance);
+    }
+
+    private PerformanceResponseDto getCachedPerformance(UUID performanceId, String cacheKey, String rankKey) {
+        PerformanceResponseDto cachedPerformance = (PerformanceResponseDto) redisTemplate.opsForValue().get(cacheKey);
+        // 3. 조회수 증가
+        redisTemplate.opsForZSet().incrementScore(rankKey, String.valueOf(performanceId), 1);
+        // 4. 캐시 데이터가 존재하면 반환
+        return cachedPerformance;
     }
 
     // 공연 전체 조회 & 검색
@@ -62,6 +82,21 @@ public class PerformanceService {
     @Transactional(readOnly = true)
     public RestPage<PerformanceResponseDto> getPerformances(String condition, String keyword, Pageable pageable) {
         return performanceRepository.findPerformanceWithConditions(condition, keyword, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceResponseDto> getPerformanceRank() {
+        String rankKey = RedisKeyHelper.getViewRankKey();
+        List<UUID> rankedPerformanceIds = redisTemplate.opsForZSet().reverseRangeWithScores(rankKey, 0, 5).stream().map(
+                z -> UUID.fromString(z.getValue().toString())
+        ).toList();
+        List<PerformanceResponseDto> rankedPerformances = new ArrayList<>();
+        for (UUID rankedPerformanceId : rankedPerformanceIds) {
+            String cacheKey = RedisKeyHelper.getEventDetailCacheKey(rankedPerformanceId);
+            PerformanceResponseDto cachedPerformance = getCachedPerformance(rankedPerformanceId, cacheKey, rankKey);
+            rankedPerformances.add(cachedPerformance);
+        }
+        return rankedPerformances;
     }
 
     // 공연 상태 수정
@@ -91,7 +126,6 @@ public class PerformanceService {
         Performance performance = findPerformanceById(performanceId);
         performance.setDeletedBy(username);
     }
-
 
     private void checkDuplicateTitle(String title) {
         if (performanceRepository.existsByTitle(title)) {

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/PerformanceService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/PerformanceService.java
@@ -87,6 +87,8 @@ public class PerformanceService {
         } else {
             Cookie newCookie = new Cookie("View_Count", "[" + performanceId + "]");
             newCookie.setPath("/");
+            newCookie.setHttpOnly(true);
+            newCookie.setMaxAge(24 * 60 * 60);
             redisTemplate.opsForZSet().incrementScore(rankKey, performanceId, 1);
             response.addCookie(newCookie);
         }

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/PerformanceService.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/application/service/PerformanceService.java
@@ -106,7 +106,7 @@ public class PerformanceService {
     @Transactional(readOnly = true)
     public List<PerformanceResponseDto> getPerformanceRank() {
         String rankKey = RedisKeyHelper.getViewRankKey();
-        List<UUID> rankedPerformanceIds = redisTemplate.opsForZSet().reverseRangeWithScores(rankKey, 0, 5).stream().map(
+        List<UUID> rankedPerformanceIds = redisTemplate.opsForZSet().reverseRangeWithScores(rankKey, 0, 4).stream().map(
                 z -> UUID.fromString(z.getValue().toString())
         ).toList();
         List<PerformanceResponseDto> rankedPerformances = new ArrayList<>();

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/ResponseStatus.java
@@ -32,6 +32,7 @@ public enum ResponseStatus {
     // performance
     CREATE_PERFORMANCE_SUCCESS(HttpStatus.CREATED, "공연 생성에 성공했습니다."),
     GET_PERFORMANCE_SUCCESS(HttpStatus.OK, "공연 조회에 성공했습니다."),
+    GET_RANKED_PERFORMANCES_SUCCESS(HttpStatus.OK, "공연 랭킹 조회에 성공했습니다."),
     UPDATE_PERFORMANCE_STATUS_SUCCESS(HttpStatus.OK, "공연 상태 수정에 성공했습니다."),
     UPDATE_PERFORMANCE(HttpStatus.OK, "공연 수정에 성공했습니다."),
     DELETE_PERFORMANCE_SUCCESS(HttpStatus.OK, "공연 삭제에 성공했습니다."),

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/RedisKeyHelper.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/RedisKeyHelper.java
@@ -1,0 +1,20 @@
+package com.culture_ticket.client.performance.common.util;
+
+import java.util.UUID;
+
+public class RedisKeyHelper {
+
+    private RedisKeyHelper() {
+        // Prevent instantiation
+    }
+
+    // 매개변수로 받은 id값의 event의 details의 키를 반환.
+    public static String getEventDetailCacheKey(UUID performanceId) {
+        return RedisKeyType.PERFORMANCE_INFO.format(performanceId);
+    }
+
+    //
+    public static String getViewRankKey() {
+        return RedisKeyType.PERFORMANCE_VIEW_RANK.format();
+    }
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/RedisKeyHelper.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/RedisKeyHelper.java
@@ -9,7 +9,7 @@ public class RedisKeyHelper {
     }
 
     // 매개변수로 받은 id값의 event의 details의 키를 반환.
-    public static String getEventDetailCacheKey(UUID performanceId) {
+    public static String getPerformanceDetailsKey(UUID performanceId) {
         return RedisKeyType.PERFORMANCE_INFO.format(performanceId);
     }
 

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/RedisKeyType.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/RedisKeyType.java
@@ -1,0 +1,17 @@
+package com.culture_ticket.client.performance.common.util;
+
+
+public enum RedisKeyType {
+    PERFORMANCE_INFO("performance:detail:%s"),
+    PERFORMANCE_VIEW_RANK("performance:rank:view");
+
+    private final String keyPattern;
+
+    RedisKeyType(String keyPattern) {
+        this.keyPattern = keyPattern;
+    }
+
+    public String format(Object... args) {
+        return String.format(keyPattern, args);
+    }
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/ScheduledTaskExecutor.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/common/util/ScheduledTaskExecutor.java
@@ -1,0 +1,27 @@
+package com.culture_ticket.client.performance.common.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduledTaskExecutor {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Scheduled(cron = "0 0 0 * * SUN") // 매주 일요일 자정에 실행
+    public void resetPerformanceRedisCache() {
+        String pattern = "performance*";
+        Set<String> keys = redisTemplate.keys(pattern);
+        if (!keys.isEmpty()) {
+            redisTemplate.delete(keys);
+            System.out.println("Deleted keys: " + keys);
+        } else {
+            System.out.println("No keys found matching pattern: " + pattern);
+        }
+    }
+}

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/infrastructure/config/CacheConfig.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/infrastructure/config/CacheConfig.java
@@ -63,7 +63,7 @@ public class CacheConfig {
     public CacheManager cacheManager() {
         // 기본 Redis 캐시 설정
         RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(5))  // 캐시 TTL 설정 (5분)
+                .entryTtl(Duration.ofDays(7))  // 캐시 TTL 설정 (7일)
                 .disableCachingNullValues()
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(genericJackson2JsonRedisSerializer()));
 

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/PerformanceController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/PerformanceController.java
@@ -12,6 +12,8 @@ import com.culture_ticket.client.performance.common.ResponseDataDto;
 import com.culture_ticket.client.performance.common.ResponseMessageDto;
 import com.culture_ticket.client.performance.common.ResponseStatus;
 import com.culture_ticket.client.performance.domain.service.PerformanceDomainService;
+
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -64,6 +66,12 @@ public class PerformanceController {
     ) {
         RestPage<PerformanceResponseDto> performances = performanceService.getPerformances(condition, keyword, pageable);
         return new ResponseDataDto<>(ResponseStatus.GET_PERFORMANCE_SUCCESS, performances);
+    }
+
+    @GetMapping("/rank")
+    public ResponseDataDto<List<PerformanceResponseDto>> getPerformanceRank(){
+        List<PerformanceResponseDto> rankedPerformances = performanceService.getPerformanceRank();
+        return new ResponseDataDto<>(ResponseStatus.GET_RANKED_PERFORMANCES_SUCCESS, rankedPerformances);
     }
 
     // 공연 상태 수정

--- a/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/PerformanceController.java
+++ b/com.culture-ticket.client.performance/src/main/java/com/culture_ticket/client/performance/presentation/controller/PerformanceController.java
@@ -15,6 +15,9 @@ import com.culture_ticket.client.performance.domain.service.PerformanceDomainSer
 
 import java.util.List;
 import java.util.UUID;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -52,8 +55,12 @@ public class PerformanceController {
 
     // 공연 단일 조회
     @GetMapping("/info/{performanceId}")
-    public ResponseDataDto<PerformanceResponseDto> getPerformance(@PathVariable UUID performanceId) {
-        PerformanceResponseDto performanceResponseDto = performanceService.getPerformance(performanceId);
+    public ResponseDataDto<PerformanceResponseDto> getPerformance(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            @PathVariable UUID performanceId
+    ) {
+        PerformanceResponseDto performanceResponseDto = performanceService.getPerformance(request, response, performanceId);
         return new ResponseDataDto<>(ResponseStatus.GET_PERFORMANCE_SUCCESS, performanceResponseDto);
     }
 


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feature/#46-rank -> dev
### 이슈
- #46
### Description
- 공연 조회 시 redis의 sorted set 구조의 데이터에 해당 공연id의 score(조회수)가 증가합니다.
- 반환 시 쿠키에 공연 id를 넣어 쿠키에 공연 id가 있는 사용자일 경우 재요청해도 score(조회수)가 증가하지 않습니다.
- rank 조회 시 조회수 상위 5개의 데이터가 반환되도록 구현했습니다.
### To Reviewers
- 리뷰받고 싶은 부분에 대해 작성